### PR TITLE
Updates for Turtle WoW (May 3rd, 2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Next Up
 
 ### Recently Done
 
+1.1.1b (Pull request bugfix)
+
+- Updated minimum chat limit on *Turtle WoW* from level 5 to level 10
+
 1.1.1
 
 - Directory, when ordered, now snaps user back to the top of the scrollbar

--- a/TurtleRP.toc
+++ b/TurtleRP.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: TurtleRP - |cffabd473TTRP
 ## Author: tempranova / Drixi / Vee
-## Version: 1.1.0
+## Version: 1.1.1b
 ## Notes: RP Addon custom made for Turtle WoW
 ## SavedVariables: TurtleRPSettings, TurtleRPCharacters, TurtleRPQueryablePlayers
 ## SavedVariablesPerCharacter: TurtleRPCharacterInfo

--- a/scripts/TurtleRP.lua
+++ b/scripts/TurtleRP.lua
@@ -13,7 +13,7 @@ TurtleRP.currentVersion = "1.1.1b"
 TurtleRP.latestVersion = TurtleRP.currentVersion
 -- Chat
 TurtleRP.channelName = "TTRP"
--- TurtleRP.channelIndex = 0
+TurtleRP.channelIndex = 0
 TurtleRP.timeBetweenPings = 30
 TurtleRP.currentlyRequestedData = nil
 TurtleRP.disableMessageSending = nil

--- a/scripts/TurtleRP.lua
+++ b/scripts/TurtleRP.lua
@@ -9,11 +9,11 @@
 TurtleRP.TestMode = 0
 
 -- Dev
-TurtleRP.currentVersion = "1.1.1"
+TurtleRP.currentVersion = "1.1.1b"
 TurtleRP.latestVersion = TurtleRP.currentVersion
 -- Chat
 TurtleRP.channelName = "TTRP"
-TurtleRP.channelIndex = 0
+-- TurtleRP.channelIndex = 0
 TurtleRP.timeBetweenPings = 30
 TurtleRP.currentlyRequestedData = nil
 TurtleRP.disableMessageSending = nil
@@ -149,8 +149,8 @@ function TurtleRP:OnEvent()
     TurtleRP.log("Welcome, |cff8C48AB" .. TurtleRPCharacterInfo["full_name"] .. "|ccfFFFFFF, to TurtleRP.")
     TurtleRP.log("Type |cff8C48AB/ttrp |ccfFFFFFFto open the addon, or |cff8C48AB/ttrp help|ccfFFFFFF to see slash commands.")
 
-    if GetRealmName() == "Turtle WoW" and UnitLevel("player") < 5 and UnitLevel("player") ~= 0 then
-      TurtleRP.log("|cff8C48ABSorry, but due to Turtle WoW restrictions you can't access other player's TurtleRP profiles until level 5.")
+    if GetRealmName() == "Turtle WoW" and UnitLevel("player") < 10 and UnitLevel("player") ~= 0 then
+      TurtleRP.log("|cff8C48ABSorry, but due to Turtle WoW restrictions you can't access other player's TurtleRP profiles until level 10.")
     end
 
     TurtleRP.communication_prep()

--- a/scripts/TurtleRPComms.lua
+++ b/scripts/TurtleRPComms.lua
@@ -90,7 +90,7 @@ end
 
 -- This function often runs too early
 function TurtleRP.communication_prep()
-  if UnitLevel("player") > 4 then
+  if UnitLevel("player") > 9 then
     TurtleRP.pingWithLocationAndVersion("A")
   end
 
@@ -114,7 +114,7 @@ function TurtleRP.communication_prep()
 end
 
 function TurtleRP.send_ping_message()
-  if UnitLevel("player") > 4 then
+  if UnitLevel("player") > 9 then
     TurtleRP.pingWithLocationAndVersion("P")
   end
 
@@ -132,7 +132,7 @@ function TurtleRP.send_ping_message()
     local st = (this.startTime + plus) * 1000
     if gt >= st then
       if TurtleRP.disableMessageSending == nil then
-        if UnitLevel("player") > 4 then
+        if UnitLevel("player") > 9 then
           TurtleRP.pingWithLocationAndVersion("P")
         end
       end
@@ -155,11 +155,11 @@ function TurtleRP.checkTTRPChannel()
   end
   if TurtleRP.channelIndex == 0 then
     JoinChannelByName(TurtleRP.channelName)
-    if UnitLevel("player") > 4 then
+    if UnitLevel("player") > 9 then
       TurtleRP.pingWithLocationAndVersion("A")
     end
   else
-    if UnitLevel("player") > 4 then
+    if UnitLevel("player") > 9 then
       TurtleRP.pingWithLocationAndVersion("A")
     end
   end


### PR DESCRIPTION
On May 3rd, 2023, *Turtle WoW* [increased the minimum chat level](https://forum.turtle-wow.org/viewtopic.php?p=44168) from 5 to 10.  I've updated the relevant files (`TurtleRP.lua` and `TurtleRPComms.lua`) for this change.