### PR TITLE
Fix for Tel'abim profiles not working.

### DIFF
--- a/scripts/TurtleRPComms.lua
+++ b/scripts/TurtleRPComms.lua
@@ -186,6 +186,12 @@ function TurtleRP.communication_events()
         TurtleRP.checkChatMessage(TurtleRP.DrunkDecode(arg1), arg2)
       end
     end
+    -- This is a fix for Tel'Abim response messages being sent erroneously to CHAT_MSG_ADDON instead of to the TTRP channel.
+    if event == "CHAT_MSG_ADDON" then
+      if string.lower(arg3) == "unknown" then
+        TurtleRP.checkChatMessage(TurtleRP.DrunkDecode(arg1), arg2)
+      end
+    end
   end)
 
 end


### PR DESCRIPTION
Profiles on Tel'Abim are not functioning at the moment, as for some reason, responses for data being requested are not being sent over the TTRP chat channel and instead are sent as "CHAT_MSG_ADDON" messages, which TTRP does not account for. I added a listener in the CheckMessages function that checks addon messages with arg3(channel name) set as "unknown". In me and my guild's testing, this restores functionality and doesn't make a noticeable impact on performance.