### PR TITLE
Heavily optimize player location updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## TurtleRP Optimized
+
+TurtleRP has an issue that causes the game to freeze frequently. This is caused by the addon generating an extreme amount of memory garbage, triggering more garbage collections, which will freeze the game for its duration. It also uses a lot of CPU, reducing average framerate. This fork addresses these issues, likely reducing resource usage by 99%+, while preserving all the functionality of the addon.
+
 ## TurtleRP
 
 An RP addon custom-made for Vanilla WoW.

--- a/TurtleRP.toc
+++ b/TurtleRP.toc
@@ -1,5 +1,5 @@
 ## Interface: 11200
-## Title: TurtleRP - |cffabd473TTRP
+## Title: TurtleRP Optimized - |cffabd473TTRP
 ## Author: tempranova / Drixi / Vee
 ## Version: 1.1.0
 ## Notes: RP Addon custom made for Turtle WoW

--- a/scripts/TurtleRPComms.lua
+++ b/scripts/TurtleRPComms.lua
@@ -178,7 +178,7 @@ function TurtleRP.communication_events()
 
   end)
 
-  local CheckMessages = CreateFrame("Frame")
+  local CheckMessages = CreateFrame("Frame", "TurtleRPMessageScanner")
   CheckMessages:RegisterEvent("CHAT_MSG_CHANNEL")
   CheckMessages:SetScript("OnEvent", function()
     if event == "CHAT_MSG_CHANNEL" then
@@ -374,13 +374,17 @@ function TurtleRP.recievePingInformation(playerName, msg)
   TurtleRPCharacters[playerName]['zone'] = zoneText
   if string.find(zoneText, '~') then
     local splitString = string.split(zoneText, "~")
-    TurtleRPCharacters[playerName]['zone'] = splitString[1]
+    local zone = splitString[1]
+    TurtleRPCharacters[playerName]['zone'] = zone
     if splitString[2] and splitString[3] then
       local zoneX = splitString[2]
       local zoneY = splitString[3]
       TurtleRPCharacters[playerName]['zoneX'] = zoneX
       TurtleRPCharacters[playerName]['zoneY'] = zoneY
-      TurtleRP.show_player_locations()
+      -- Only update player locations if the player is in the zone we're looking at
+      if zone == TurtleRP.GetZones(GetCurrentMapContinent())[GetCurrentMapZone()] then
+        TurtleRP.show_player_locations()
+      end
     end
   end
 end

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -36,14 +36,19 @@ end
 function TurtleRP.show_player_locations()
   local onlinePlayers = TurtleRP.get_players_online()
   local createdFrames = 0
-  for i, v in onlinePlayers do
-    if i ~= UnitName("player") then
-      local zonesByID = TurtleRP.LoadZones(GetMapZones(GetCurrentMapContinent()))
-      if TurtleRPCharacters[i] and TurtleRPCharacters[i]['zone'] == zonesByID[GetCurrentMapZone()] then
-        if TurtleRPCharacters[i]['zoneX'] and TurtleRPCharacters[i]['zoneY'] then
-          if TurtleRPCharacters[i]['zoneX'] ~= "false" and TurtleRPCharacters[i]['zoneY'] ~= "false" then
-            local zoneX = tonumber(TurtleRPCharacters[i]['zoneX'])
-            local zoneY = tonumber(TurtleRPCharacters[i]['zoneY'])
+  local zonesByID = TurtleRP.GetZones(GetCurrentMapContinent())
+  local currentZone = GetCurrentMapZone()
+  local selfName = UnitName("player")
+  for charName, character in pairs(onlinePlayers) do
+    if charName ~= selfName then
+      local zone = character["zone"]
+      local zoneX = character["zoneX"]
+      local zoneY = character["zoneY"]
+      if character and zone == zonesByID[currentZone] then
+        if zoneX and zoneY then
+          if zoneX ~= "false" and zoneY ~= "false" then
+            zoneX = tonumber(zoneX)
+            zoneY = tonumber(zoneY)
             local playerPositionFrame = getglobal("TurtleRP_MapPlayerPosition_" .. createdFrames)
             if playerPositionFrame == nil then
               playerPositionFrame = CreateFrame("Button", "TurtleRP_MapPlayerPosition_" .. createdFrames, WorldMapDetailFrame, "TurtleRP_WorldMapUnitTemplate")
@@ -53,9 +58,9 @@ function TurtleRP.show_player_locations()
             local mapLeft = WorldMapDetailFrame:GetLeft()
             local mapHeight = WorldMapDetailFrame:GetHeight()
             local mapLeft = WorldMapDetailFrame:GetLeft()
-            playerPositionFrame.full_name = i
-            if TurtleRPCharacters[i]['full_name'] ~= nil and TurtleRPCharacters[i]['full_name'] ~= "" then
-              playerPositionFrame.full_name = TurtleRPCharacters[i]['full_name']
+            playerPositionFrame.full_name = charName
+            if character['full_name'] ~= nil and character['full_name'] ~= "" then
+              playerPositionFrame.full_name = character['full_name']
             end
             playerPositionFrame:SetPoint("CENTER", WorldMapDetailFrame, "TOPLEFT", zoneX * mapWidth, zoneY * mapHeight * -1)
             playerPositionFrame:Show()
@@ -157,12 +162,16 @@ function TurtleRP.renderDirectory(directoryOffset)
   end
 end
 
+local onlinePlayers = {}
 function TurtleRP.get_players_online()
-  local onlinePlayers = {}
-  for i, v in TurtleRPCharacters do
+  for k, v in pairs(onlinePlayers) do
+    onlinePlayers[k] = nil
+  end
+  local currentTime = time()
+  for i, v in pairs(TurtleRPCharacters) do
     if TurtleRPQueryablePlayers[i] then
       if type(TurtleRPQueryablePlayers[i]) == "number" then
-        if TurtleRPQueryablePlayers[i] > (time() - 65) then
+        if TurtleRPQueryablePlayers[i] > (currentTime - 65) then
           onlinePlayers[i] = v
         end
       end
@@ -192,6 +201,14 @@ function TurtleRP.LoadZones(...)
     info[i] = arg[i]
   end
   return info
+end
+
+TurtleRP.ContinentCache = {}
+function TurtleRP.GetZones(continentID)
+    if not TurtleRP.ContinentCache[continentID] then
+        TurtleRP.ContinentCache[continentID] = TurtleRP.LoadZones(GetMapZones(continentID))
+    end
+    return TurtleRP.ContinentCache[continentID]
 end
 
 function TurtleRP.Directory_FrameDropDown_OnClick()


### PR DESCRIPTION
The player location updates cause an extreme amount of garbage to be generated, leading to frequent garbage collections, freezing the game. The location updates are also very CPU expensive as well. This PR addresses those issues by caching key data and only updating maps when a player is looking at the zone the message sender is in.